### PR TITLE
refactor: remove shebang and move imports

### DIFF
--- a/thermal.py
+++ b/thermal.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python3
+from escpos.printer import Usb
+from PIL import Image
+
 import sys
 import os
 import argparse
 import subprocess
 import tempfile
-from escpos.printer import Usb
-from PIL import Image
 import textwrap
 
 # Global variables


### PR DESCRIPTION
Removes the shebang line and moves the imports to the top of the file for better readability and style.